### PR TITLE
Configuracion Heroku

### DIFF
--- a/votos/settings/production.py
+++ b/votos/settings/production.py
@@ -13,5 +13,4 @@ WSGI_APPLICATION = 'votos.wsgi_production.application'
 
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_KEY'),
-    'release': raven.fetch_git_sha(os.path.abspath(os.pardir)),
 }


### PR DESCRIPTION
Quite la variable `release`
 de las configuraciones de RAVEN_CONFIG