### PR TITLE
Devcontainer trust localhost https

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Selenium Tests",
+  "name": "Django",
   "dockerComposeFile": ["local.yml", "docker-compose.extend.yml"],
   "service": "workspace",
   "shutdownAction": "stopCompose",
@@ -11,9 +11,6 @@
     "DATABASE_URL": "postgres://${containerEnv:POSTGRES_USER}:${containerEnv:POSTGRES_PASSWORD}@${containerEnv:POSTGRES_HOST}:${containerEnv:POSTGRES_PORT}/${containerEnv:POSTGRES_DB}"
   },
   "customizations": {
-    "codespaces": {
-      "openFiles": []
-    },
     "vscode": {
       "settings": {
         "python.testing.pytestArgs": ["tests"],

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -60,3 +60,4 @@ INSTALLED_APPS += ["django_extensions"]  # noqa: F405
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+CSRF_TRUSTED_ORIGINS = ["https://localhost:8000", "http://localhost:8000"]


### PR DESCRIPTION
Este PR se envia por que en codespaces hay un inconvenente con cors al usar devcontainers, aunque hay que probar dicho formulario localmente