### PR TITLE
Añadir listado de charlas propuestas (Issue #243)

### DIFF
--- a/temii/talks/urls.py
+++ b/temii/talks/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
-from .views import talk_create_view
+from .views import talk_create_view, talk_list_view
 
 app_name = "talks"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/about.html"), name="talks"),
     path("~create/", view=talk_create_view, name="create"),
     path("thanks/", TemplateView.as_view(template_name="talks/talk_thanks.html"), name="thanks"),
+    path("~my-talks/", view=talk_list_view, name="list"),
 ]

--- a/temii/talks/views.py
+++ b/temii/talks/views.py
@@ -1,10 +1,21 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
+from django.views.generic import ListView
 from django.views.generic.edit import CreateView
 
 from .forms import NewTalkForm
 from .models import Talk
 
+
+class TalkListView(LoginRequiredMixin, ListView):
+    """List all authenticated user talks."""
+
+    model = Talk
+    context_object_name = "talks"
+    template_name = "talks/list.html"
+
+    def get_queryset(self):
+        return Talk.objects.filter(user=self.request.user)
 
 class TalkCreateView(LoginRequiredMixin, CreateView):
     """Propose a new talk."""
@@ -18,5 +29,5 @@ class TalkCreateView(LoginRequiredMixin, CreateView):
         form.instance.user = self.request.user
         return super().form_valid(form)
 
-
+talk_list_view = TalkListView.as_view()
 talk_create_view = TalkCreateView.as_view()

--- a/temii/templates/base.html
+++ b/temii/templates/base.html
@@ -66,6 +66,9 @@
                   <a class="nav-link" href="{% url 'users:detail' request.user.username %}">{% translate "My Profile" %}</a>
                 </li>
                 <li class="nav-item">
+                  <a class="nav-link" href="{% url 'talks:list' %}">{% translate "My Talks" %}</a>
+                </li>
+                <li class="nav-item">
                   <a class="nav-link" href="{% url 'talks:create' %}">{% translate "Propose a talk" %}</a>
                 </li>
                 <li class="nav-item">

--- a/temii/templates/talks/talk_list.html
+++ b/temii/templates/talks/talk_list.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}My Talks{% endblock %}
+
+{% block content %}
+
+<h2>My Talks</h2>
+
+{% if talks %}
+<p>Here you have all the talks you've proposed. </p>
+{% endif %}
+
+<ul>
+    {% for talk in talks %}
+        <li>Title: {{ talk.name }} - Proposed Month: {{ talk.months }}</li>
+    {% empty %}
+    <li>You haven't proposed any talk yet. <a href="{% url 'talks:create' %}">Propose a new one!</a></li>
+    {% endfor %}
+</ul>
+
+
+
+{% endblock content %}


### PR DESCRIPTION
Se agrega botón en la barra de navegación "My Talks" para los usuarios logueados. Este redirecciona a una página con el listado de charlas relacionadas a un usuario logueado.

# Pull request

Closes #243

**Barra de navegación de un usuario no logueado:**

![image](https://github.com/user-attachments/assets/b01d913b-198d-4b09-8a49-47600d3f1e59)

**Barra de navegación de un usuario logueado:**

![image](https://github.com/user-attachments/assets/5b976928-4808-485e-95e9-2202e991a18b)

**Sección con el listado de charlas relacionadas con un usuario logueado:**

![image](https://github.com/user-attachments/assets/9f7c3c8c-ba98-44e6-b6b5-cd901e7eaedb)

